### PR TITLE
[전체 QA] 설정 페이지 툴팁 문구 개선 (API KEY 미 등록 사용자) - API KEY 등록 시 툴팁 늘어남 현상 수정.

### DIFF
--- a/src/pages/service/setting/styles/setting.css
+++ b/src/pages/service/setting/styles/setting.css
@@ -69,14 +69,14 @@ main .card.user-profile .card-box .binance-link-status .expose-info-btn .info-bo
     align-items: flex-start;
     gap: 5px;
     text-align: left;
-    width: 360px;
+    width: auto;
     min-width: unset;
 
     word-break: keep-all;
     overflow-wrap: break-word;
 }
 main .card.user-profile .card-box .binance-link-status .expose-info-btn .info-box p {
-    white-space: normal;
+    white-space: nowrap;
     line-height: 1.6;
 }
 main .card.user-profile .card-box .binance-link-status .expose-info-btn:hover .info-box {


### PR DESCRIPTION
이전 커밋에서 
1. API키 미입력 시 - 안내문구 추가
2. API 키 입력 시 - 기존 동일
이었으나,

2번 케이스일 시, 툴팁 박스가 가로로 쓸데없이 늘어나 해당 부분 재수정