### PR TITLE
[전체 QA] 탈퇴 후 재가입 시 (버그 상 노출되는)얼럿 문구 "메인페이지" 수정 필요

### DIFF
--- a/src/scripts/libraries/CommonLib.js
+++ b/src/scripts/libraries/CommonLib.js
@@ -23,11 +23,11 @@ const checkAuthorization = async (type) => {
 
             case 'UNAUTHORIZED':
             default:
-                alert('접근 권한이 없습니다. 메인 페이지로 이동합니다.');
+                alert('접근 권한이 없습니다. 로그인 페이지로 이동합니다.');
                 window.location.href = '/login';
         }
     } catch (error) {
-        alert('인증 과정에서 문제가 발생했습니다. 메인 페이지로 이동합니다.');
+        alert('인증 과정에서 문제가 발생했습니다. 로그인 페이지로 이동합니다.');
         window.location.href = '/login';
     }
 };


### PR DESCRIPTION
현재 해당 이슈 발현 중에 있지 않으나,
안내문구를 

- 접근 권한이 없습니다. 로그인 페이지로 이동합니다. ->  접근 권한이 없습니다. 로그인 페이지로 이동합니다.
- 인증 과정에서 문제가 발생했습니다. 로그인 페이지로 이동합니다. -> 인증 과정에서 문제가 발생했습니다. 로그인 페이지로 이동합니다.

해당 문구로 변경 소요가 있어 
PR 요청 드립니다.